### PR TITLE
Add ability to set library path via COMPLEASM_LIBRARY_PATH if --library_path unspecified

### DIFF
--- a/compleasm.py
+++ b/compleasm.py
@@ -73,8 +73,12 @@ class Downloader:
     def __init__(self, download_dir=None, download_lineage=True, download_placement=True):
         self.base_url = "https://busco-data.ezlab.org/v5/data/"
         self.default_lineage = ["eukaryota_odb10"]
-        if download_dir is None:
-            self.download_dir = "mb_downloads"
+        if download_dir == None:
+            library_path_env = os.getenv("COMPLEASM_LIBRARY_PATH")
+            if library_path_env is None:
+                self.download_dir = "mb_downloads"
+            else:
+                self.download_dir = library_path_env
         else:
             self.download_dir = download_dir
 
@@ -2634,9 +2638,10 @@ def main():
     download_parser = subparser.add_parser("download", help="Download specified BUSCO lineages")
     download_parser.add_argument("lineages", type=str, nargs='+',
                                  help="Specify the names of the BUSCO lineages to be downloaded. (e.g. eukaryota, primates, saccharomycetes etc.)")
-    download_parser.add_argument("-L", "--library_path", type=str, default="mb_downloads",
-                                 help="The destination folder to store the downloaded lineage files."
-                                      "If not specified, a folder named \"mb_downloads\" will be created on the current running path.")
+    download_parser.add_argument("-L", "--library_path", type=str, default=None,
+                                 help="The destination folder to store the downloaded lineage files. "
+                                      "If not specified, the environment variable COMPLEASM_LIBRARY_PATH is used. "
+                                      "If that is not set, a folder named \"mb_downloads\" will be created on the current running path.")
     download_parser.set_defaults(func=download)
 
     ### sub-command: list
@@ -2652,8 +2657,10 @@ def main():
     protein_parser.add_argument("-l", "--lineage", type=str, help="BUSCO lineage name", required=True)
     protein_parser.add_argument("-o", "--outdir", type=str, help="Output analysis folder", required=True)
     protein_parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", default=1)
-    protein_parser.add_argument("-L", "--library_path", type=str, default="mb_downloads",
-                                help="Folder path to stored lineages. ")
+    protein_parser.add_argument("-L", "--library_path", type=str, default=None,
+                                help="Folder path to stored lineages. "
+                                     "If not specified, the environment variable COMPLEASM_LIBRARY_PATH is used. "
+                                     "If that is not set, a folder named \"mb_downloads\" on the current running path will be used.")
     protein_parser.add_argument("--hmmsearch_execute_path", type=str, default=None, help="Path to hmmsearch executable")
     protein_parser.set_defaults(func=protein_fun)
 
@@ -2678,8 +2685,10 @@ def main():
     analysis_parser.add_argument("-l", "--lineage", type=str, help="BUSCO lineage name", required=True)
     analysis_parser.add_argument("-o", "--output_dir", type=str, help="Output analysis folder", required=True)
     analysis_parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", default=1)
-    analysis_parser.add_argument("-L", "--library_path", type=str, default="mb_downloads",
-                                 help="Folder path to stored lineages. ")
+    analysis_parser.add_argument("-L", "--library_path", type=str, default=None,
+                                 help="Folder path to stored lineages. "
+                                      "If not specified, the environment variable COMPLEASM_LIBRARY_PATH is used. "
+                                      "If that is not set, a folder named \"mb_downloads\" on the current running path will be used.")
     analysis_parser.add_argument("-m", "--mode", type=str, choices=["lite", "busco"], default="busco",
                                  help="The mode of evaluation. dafault mode: busco.\n"
                                       "lite:  Without using hmmsearch to filtering protein alignment.\n"
@@ -2708,9 +2717,10 @@ def main():
     run_parser.add_argument("-t", "--threads", type=int, default=1, help="Number of threads to use")
     run_parser.add_argument("-l", "--lineage", type=str, default=None,
                             help="Specify the name of the BUSCO lineage to be used. (e.g. eukaryota, primates, saccharomycetes etc.)")
-    run_parser.add_argument("-L", "--library_path", type=str, default="mb_downloads",
+    run_parser.add_argument("-L", "--library_path", type=str, default=None,
                             help="Folder path to download lineages or already downloaded lineages. "
-                                 "If not specified, a folder named \"mb_downloads\" will be created on the current running path by default to store the downloaded lineage files.")
+                                 "If not specified, the environment variable COMPLEASM_LIBRARY_PATH is used. "
+                                 "If that is not set, a folder named \"mb_downloads\" on the current running path will be used or created.")
     run_parser.add_argument("-m", "--mode", type=str, choices=["lite", "busco"], default="busco",
                             help="The mode of evaluation. dafault mode: busco.\n"
                                  "lite:  Without using hmmsearch to filtering protein alignment.\n"
@@ -2741,6 +2751,13 @@ def main():
         sys.exit()
 
     args = parser.parse_args()
+    # if --library_path unspecified, check COMPLEASM_LIBRARY_PATH. If unset, use "mb_downloads" as default
+    if args.library_path == None:
+        library_path_env = os.getenv("COMPLEASM_LIBRARY_PATH")
+        if library_path_env is None:
+            args.library_path = "mb_downloads"
+        else:
+            args.library_path = library_path_env
     args.func(args)
 
 


### PR DESCRIPTION
Adds the ability to specify the library path (what is set via `--library_path`) using the environment variable `COMPLEASM_LIBRARY_PATH`. The logic is:

1. change default for `--library_path` options wherever they appear to `None`
2. at the end of argument processing, if `args.library_path == None`, then check if environment variable `COMPLEASM_LIBRARY_PATH` is set
3. if it is set, use its value for `args.library_path`
4. if it is not set, use the current default value, `mb_downloads`, which will be in the current directory

This also modifies the `__init__` logic in `Downloader` to do the same.

This change enables using a central location for lineage sets, useful for streamlining project-wide storage or, for example, for HPC clusters such as ours where we've already downloaded the lineage sets to the same system-wide location for both BUSCO and compleasm. These lineage sets do not often change, so enabling the use of a common location for them is not just feasible but recommended.