### PR TITLE
Fix pandas FutureWarning

### DIFF
--- a/compleasm.py
+++ b/compleasm.py
@@ -1278,7 +1278,7 @@ class MiniprotAlignmentParser:
 
             # remaining genes
             for gene_id in filtered_species:
-                mapped_records = grouped_df.get_group(gene_id)
+                mapped_records = grouped_df.get_group((gene_id,))
                 mapped_records = mapped_records.sort_values(by=["I+L"], ascending=False)
                 if self.specified_contigs is not None:
                     mapped_records = mapped_records[mapped_records["Contig_id"].isin(self.specified_contigs)]
@@ -1541,7 +1541,7 @@ class MiniprotAlignmentParser:
             full_table_busco_format_writer.write(
                 "# Busco id\tStatus\tSequence\tGene Start\tGene End\tStrand\tScore\tLength\tOrthoDB url\tDescription\n")
         for gene_id in all_species:
-            mapped_records = grouped_df.get_group(gene_id)
+            mapped_records = grouped_df.get_group((gene_id,))
             mapped_records = mapped_records.sort_values(by=["I+L"], ascending=False)
             if self.specified_contigs is not None:
                 mapped_records = mapped_records[mapped_records["Contig_id"].isin(self.specified_contigs)]


### PR DESCRIPTION
This patch should fix the following warnings I was getting; output is the same:

```
compleasm.py:1544: FutureWarning: When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group in 
a future version of pandas. Pass `(name,)` instead of `name` to silence this warning.
```